### PR TITLE
initial non-working maven plugin

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly-extras</groupId>
+    <artifactId>batavia-parent</artifactId>
+    <version>1.0.0.Alpha1-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.transformer</groupId>
+  <artifactId>transformer-maven-plugin</artifactId>
+  <packaging>maven-plugin</packaging>
+  <name>maven-plugin Maven Mojo</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+      <dependency>
+          <groupId>org.apache.maven.plugin-tools</groupId>
+          <artifactId>maven-plugin-annotations</artifactId>
+          <version>3.6.0</version>
+      </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.6.3</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven-plugin/src/main/java/org/wildfly/transformer/MavenPluginTransformer.java
+++ b/maven-plugin/src/main/java/org/wildfly/transformer/MavenPluginTransformer.java
@@ -1,0 +1,132 @@
+package org.wildfly.transformer;
+
+/*
+ * Copyright 2020 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transform inputJar to outputJar.
+ *
+ * @goal touch
+ * @phase process-sources
+ */
+@Mojo(name = "enhance", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class MavenPluginTransformer
+        extends AbstractMojo {
+
+    
+    @Parameter(defaultValue = "${project.basedir}", readonly = true)
+    private File projectRootFolder;
+    
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject mavenProject;
+    
+    @Parameter(defaultValue = "${project.groupId}", required = true, readonly = true)
+    private String groupId;
+    
+    @Parameter(defaultValue = "${project.artifactId}", required = true, readonly = true)
+    private String artifactId;
+    
+    @Parameter(defaultValue = "${project.version}", required = true, readonly = true)
+    private String version;
+    
+    @Parameter(defaultValue = "${project.packaging}", required = true, readonly = true)
+    private String packaging;
+    
+    @Parameter(defaultValue = "${project.build.outputDirectory}", required = true, readonly = true)
+    private String outputFolder;
+    
+    @Parameter(defaultValue = "${project.compileClasspathElements}", required = true, readonly = true)
+    private List<String> compileClasspathElements;
+    
+    //@Parameter(defaultValue = "inputJar.jar",required = false)
+    //private File inputJar;
+
+    //@Parameter(defaultValue = "outputJar.jar",required = false)
+    //private File outputJar;
+
+    public void execute()
+            throws MojoExecutionException {
+        dump();
+
+        //if (!outputJar.exists()) {
+        //    outputJar.mkdirs();
+        //}
+        //
+        //if (!inputJar.exists()) {
+        //    throw new MojoExecutionException("input file " + inputJar.getName() + " does not exist");
+        //}
+        System.out.println("TODO: load transformer and run transformer");
+    }
+
+    void dump() {
+        System.out.println("dump of maven Mojo state stuff:");
+        Map pluginContext = getPluginContext();
+        // show plugin context map key + values
+        for (Object key : pluginContext.keySet()) {
+            System.out.println("plugin context key: " + key +
+                    " value: " + pluginContext.get(key));
+        }
+        System.out.println("projectRootFolder = " + projectRootFolder);
+        System.out.println("mavenProject = " + mavenProject);
+        System.out.println("groupId = " + groupId);
+        System.out.println("artifactId = " + artifactId);
+        System.out.println("version = " + version);
+        System.out.println("packaging = " + packaging);
+        System.out.println("outputFolder = " + outputFolder);
+        if (outputFolder != null) {
+            try {
+                Process process = Runtime.getRuntime().exec("tree " + outputFolder);
+                int exitValue = 0;
+                try {
+                    exitValue = process.waitFor();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                if (exitValue != 0) {
+                    System.out.println("ls command failed with: " + exitValue);
+                }
+                String line;
+                BufferedReader br = 
+                        new BufferedReader(new InputStreamReader(process.getInputStream()));
+                while ((line = br.readLine()) != null) {
+                    System.out.println(line);
+                }
+                process.destroy();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        System.out.println("compileClasspathElements = " + compileClasspathElements);
+        
+        
+    }
+}

--- a/maven-plugin/src/test/java/org/wildfly/transformer/TestMavenPlugin.java
+++ b/maven-plugin/src/test/java/org/wildfly/transformer/TestMavenPlugin.java
@@ -1,0 +1,9 @@
+package org.wildfly.transformer;
+
+/**
+ * TestMavenPlugin
+ *
+ * @author Scott Marlow
+ */
+public class TestMavenPlugin {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
   <modules>
     <module>api</module>
     <module>impl</module>
+    <module>maven-plugin</module>
   </modules>
 
 </project>


### PR DESCRIPTION
For exploration of next steps (e.g. process .class, .xml, whatever files directly or process jars after they are built or as part of being built).

Note, the test is empty, as I started hacking with this plugin from wildfly root or jpa folder.  The hacked plugin just dumps some parameters passed in and also shows the contents of the ${project.build.outputDirectory} folder.  Also shows the contents of what MavenProject.toString() returns.

I think that the next step is to wire up one of the transformer services to be loaded and called for contents of ${project.build.outputDirectory} or perhaps on an input jar and produce a transformed output jar.
