### PR TITLE
repackage tool classes

### DIFF
--- a/tools/src/main/java/org/wildfly/transformer/tool/cmdline/Main.java
+++ b/tools/src/main/java/org/wildfly/transformer/tool/cmdline/Main.java
@@ -18,7 +18,7 @@ package org.wildfly.transformer.tool.cmdline;
 import java.io.File;
 import java.io.IOException;
 
-import org.wildfly.transformer.transformer.tool.shared.Common;
+import org.wildfly.transformer.tool.shared.Common;
 
 
 /**

--- a/tools/src/main/java/org/wildfly/transformer/tool/maven/HandleTransformation.java
+++ b/tools/src/main/java/org/wildfly/transformer/tool/maven/HandleTransformation.java
@@ -1,9 +1,9 @@
-package org.wildfly.transformer;
+package org.wildfly.transformer.tool.maven;
 
 import java.io.File;
 import java.io.IOException;
 
-import org.wildfly.transformer.transformer.tool.shared.Common;
+import org.wildfly.transformer.tool.shared.Common;
 
 /**
  * HandleTransformation

--- a/tools/src/main/java/org/wildfly/transformer/tool/maven/MavenPluginTransformer.java
+++ b/tools/src/main/java/org/wildfly/transformer/tool/maven/MavenPluginTransformer.java
@@ -1,4 +1,4 @@
-package org.wildfly.transformer;
+package org.wildfly.transformer.tool.maven;
 
 /*
  * Copyright 2020 The Apache Software Foundation.

--- a/tools/src/main/java/org/wildfly/transformer/tool/shared/Common.java
+++ b/tools/src/main/java/org/wildfly/transformer/tool/shared/Common.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.transformer.transformer.tool.shared;
+package org.wildfly.transformer.tool.shared;
 
 import java.io.Closeable;
 import java.io.File;


### PR DESCRIPTION
Minor change to clean up tool packages.

Question, should we allow the command line/maven plugin to specific which transformer to use by name?  For both, we can have a default transformer but allow the user to specify which one to use.  

Perhaps TransformerFactory should keep a Map<String,TransformerFactory> and code something like:
```
public static TransformerFactory getInstance() {
        return default instance if available;
        else return any instance available;
}

public static TransformerFactory getInstance(String name) {
        return map.get(name);
}

```