### PR TITLE
[ISSUE-43] Also need to transform javax.activation => jakarta.activation

### DIFF
--- a/api/src/main/resources/default.mapping
+++ b/api/src/main/resources/default.mapping
@@ -1,3 +1,4 @@
+javax/activation/=jakarta/activation/
 javax/annotation/security/=jakarta/annotation/security/
 javax/annotation/sql/=jakarta/annotation/sql/
 javax/annotation/G=jakarta/annotation/G


### PR DESCRIPTION
For [issues/43](https://github.com/wildfly-extras/batavia/issues/43).
Activation classes references also need to be transformed to Jakarta.  FYI, Source repo for Activation is at [jakarta/activation](https://github.com/eclipse-ee4j/jaf/tree/master/activation/src/main/java/jakarta/activation)