### PR TITLE
merged with open-liberty/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties with some reordering to allow easy future merging as needed

### DIFF
--- a/impl/ecl/src/main/resources/org/wildfly/extras/transformer/eclipse/jakarta-direct.properties
+++ b/impl/ecl/src/main/resources/org/wildfly/extras/transformer/eclipse/jakarta-direct.properties
@@ -1,7 +1,42 @@
+# Direct String Replacement
+
+# Jakarta Servlet
+javax.servlet.async.context_path=jakarta.servlet.async.context_path
+javax.servlet.async.mapping=jakarta.servlet.async.mapping
+javax.servlet.async.path_info=jakarta.servlet.async.path_info
+javax.servlet.async.query_string=jakarta.servlet.async.query_string
+javax.servlet.async.request_uri=jakarta.servlet.async.request_uri
+javax.servlet.async.servlet_path=jakarta.servlet.async.servlet_path
+javax.servlet.context.orderedLibs=jakarta.servlet.context.orderedLibs
+javax.servlet.context.tempdir=jakarta.servlet.context.tempdir
+javax.servlet.error.exception=jakarta.servlet.error.exception
+javax.servlet.error.exception_type=jakarta.servlet.error.exception_type
+javax.servlet.error.message=jakarta.servlet.error.message
+javax.servlet.error.request_uri=jakarta.servlet.error.request_uri
+javax.servlet.error.servlet_name=jakarta.servlet.error.servlet_name
+javax.servlet.error.status_code=jakarta.servlet.error.status_code
+javax.servlet.forward.context_path=jakarta.servlet.forward.context_path
+javax.servlet.forward.mapping=jakarta.servlet.forward.mapping
+javax.servlet.forward.path_info=jakarta.servlet.forward.path_info
+javax.servlet.forward.query_string=jakarta.servlet.forward.query_string
+javax.servlet.forward.request_uri=jakarta.servlet.forward.request_uri
+javax.servlet.forward.seen=jakarta.servlet.forward.seen
+javax.servlet.forward.servlet_path=jakarta.servlet.forward.servlet_path
+javax.servlet.include.context_path=jakarta.servlet.include.context_path
+javax.servlet.include.mapping=jakarta.servlet.include.mapping
+javax.servlet.include.path_info=jakarta.servlet.include.path_info
+javax.servlet.include.query_string=jakarta.servlet.include.query_string
+javax.servlet.include.request_uri=jakarta.servlet.include.request_uri
+javax.servlet.include.servlet_path=jakarta.servlet.include.servlet_path
+javax.servlet.request.cipher_suite=jakarta.servlet.request.cipher_suite
+javax.servlet.request.key_size=jakarta.servlet.request.key_size
+javax.servlet.request.ssl_session_id=jakarta.servlet.request.ssl_session_id
+javax.servlet.request.X509Certificate=jakarta.servlet.request.X509Certificate
+
 javax.jms.Queue=jakarta.jms.Queue
 javax.jms.Topic=jakarta.jms.Topic
 
-# JSP generation related
+# Jakarta Server Pages
 javax.servlet.*=jakarta.servlet.*
 javax.servlet.http.*=jakarta.servlet.http.*
 javax.servlet.jsp.*=jakarta.servlet.jsp.*
@@ -17,9 +52,18 @@ javax.servlet.context.tempdir=jakarta.servlet.context.tempdir
 javax.servlet.http.HttpServletRequest=jakarta.servlet.http.HttpServletRequest
 javax.servlet.http.HttpServletResponse=jakarta.servlet.http.HttpServletResponse
 javax.servlet.http.HttpSession=jakarta.servlet.http.HttpSession
+javax.servlet.jsp.functions.allowed=jakarta.servlet.jsp.functions.allowed
+javax.servlet.jsp.jspApplication=jakarta.servlet.jsp.jspApplication
+javax.servlet.jsp.jspConfig=jakarta.servlet.jsp.jspConfig
 javax.servlet.jsp.JspContext=jakarta.servlet.jsp.JspContext
 javax.servlet.jsp.JspException=jakarta.servlet.jsp.JspException
 javax.servlet.jsp.JspFactory=jakarta.servlet.jsp.JspFactory
+javax.servlet.jsp.jspOut=jakarta.servlet.jsp.jspOut
+javax.servlet.jsp.jspPage=jakarta.servlet.jsp.jspPage
+javax.servlet.jsp.jspPageContext=jakarta.servlet.jsp.jspPageContext
+javax.servlet.jsp.jspResponse=jakarta.servlet.jsp.jspResponse
+javax.servlet.jsp.jspRequest=jakarta.servlet.jsp.jspRequest
+javax.servlet.jsp.jspSession=jakarta.servlet.jsp.jspSession
 javax.servlet.jsp.JspWriter=jakarta.servlet.jsp.JspWriter
 javax.servlet.jsp.PageContext=jakarta.servlet.jsp.PageContext
 javax.servlet.jsp.PageContext.APPLICATION_SCOPE=jakarta.servlet.jsp.PageContext.APPLICATION_SCOPE
@@ -36,32 +80,6 @@ javax.servlet.jsp.tagext.SimpleTag=jakarta.servlet.jsp.tagext.SimpleTag
 javax.servlet.jsp.tagext.SimpleTagSupport=jakarta.servlet.jsp.tagext.SimpleTagSupport
 javax.servlet.jsp.tagext.Tag=jakarta.servlet.jsp.tagext.Tag
 javax.servlet.jsp.tagext.TagAdapter=jakarta.servlet.jsp.tagext.TagAdapter
-
-# Misc servlet
-javax.servlet.context.orderedLibs=jakarta.servlet.context.orderedLibs
-javax.servlet.context.tempdir=jakarta.servlet.context.tempdir
-javax.servlet.error.exception=jakarta.servlet.error.exception
-javax.servlet.error.exception_type=jakarta.servlet.error.exception_type
-javax.servlet.error.request_uri=jakarta.servlet.error.request_uri
-javax.servlet.error.servlet_name=jakarta.servlet.error.servlet_name
-javax.servlet.error.status_code=jakarta.servlet.error.status_code
-javax.servlet.error.message=jakarta.servlet.error.message
-javax.servlet.include.path_info=jakarta.servlet.include.path_info
-javax.servlet.include.request_uri=jakarta.servlet.include.request_uri
-javax.servlet.include.servlet_path=jakarta.servlet.include.servlet_path
-javax.servlet.jsp.jspApplication=jakarta.servlet.jsp.jspApplication
-javax.servlet.jsp.jspConfig=jakarta.servlet.jsp.jspConfig
-javax.servlet.jsp.jspException=jakarta.servlet.jsp.jspException
-javax.servlet.jsp.jspOut=jakarta.servlet.jsp.jspOut
-javax.servlet.jsp.jspPage=jakarta.servlet.jsp.jspPage
-javax.servlet.jsp.jspPageContext=jakarta.servlet.jsp.jspPageContext
-javax.servlet.jsp.jspRequest=jakarta.servlet.jsp.jspRequest
-javax.servlet.jsp.jspResponse=jakarta.servlet.jsp.jspResponse
-javax.servlet.jsp.jspSession=jakarta.servlet.jsp.jspSession
-javax.servlet.request.cipher_suite=jakarta.servlet.request.cipher_suite
-javax.servlet.request.key_size=jakarta.servlet.request.key_size
-javax.servlet.request.ssl_session_id=jakarta.servlet.request.ssl_session_id
-javax.servlet.request.X509Certificate=jakarta.servlet.request.X509Certificate
 
 # Jakarta Persistence
 javax.persistence.bean.manager=jakarta.persistence.bean.manager
@@ -102,9 +120,36 @@ javax.persistence.validation.group.pre-remove=jakarta.persistence.validation.gro
 javax.persistence.validation.group.pre-update=jakarta.persistence.validation.group.pre-update
 javax.persistence.validation.mode=jakarta.persistence.validation.mode
 
+# Jakarta Standard Tag Library
+javax.servlet.jsp.jstl.fmt.fallbackLocale=jakarta.servlet.jsp.jstl.fmt.fallbackLocale
+javax.servlet.jsp.jstl.fmt.locale=jakarta.servlet.jsp.jstl.fmt.locale
+javax.servlet.jsp.jstl.fmt.localizationContext=jakarta.servlet.jsp.jstl.fmt.localizationContext
+javax.servlet.jsp.jstl.fmt.request.charset=jakarta.servlet.jsp.jstl.fmt.request.charset
+javax.servlet.jsp.jstl.fmt.timeZone=jakarta.servlet.jsp.jstl.fmt.timeZone
+javax.servlet.jsp.jstl.sql.dataSource=jakarta.servlet.jsp.jstl.sql.dataSource
+javax.servlet.jsp.jstl.sql.driver=jakarta.servlet.jsp.jstl.sql.driver
+javax.servlet.jsp.jstl.sql.jdbcURL=jakarta.servlet.jsp.jstl.sql.jdbcURL
+javax.servlet.jsp.jstl.sql.maxRows=jakarta.servlet.jsp.jstl.sql.maxRows
+javax.servlet.jsp.jstl.sql.password=jakarta.servlet.jsp.jstl.sql.password
+javax.servlet.jsp.jstl.sql.userName=jakarta.servlet.jsp.jstl.sql.userName
+
+# Jakarta Server Faces
+javax.faces.validator.beanValidator.ValidatorFactory=jakarta.faces.validator.beanValidator.ValidatorFactory
+
+# Jakarta Server Pages TLD Locations
+# /javax/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd=/jakarta/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd
+# /javax/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd=/jakarta/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd
+# /javax/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd=/jakarta/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd
+# /javax/servlet/resources/XMLSchema.dtd=/jakarta/servlet/resources/XMLSchema.dtd
+# /javax/servlet/resources/datatypes.dtd=/jakarta/servlet/resources/datatypes.dtd
+# /javax/servlet/resources/j2ee_1_4.xsd=/jakarta/servlet/resources/j2ee_1_4.xsd
+# /javax/servlet/resources/j2ee_web_services_client_1_1.xsd=/jakarta/servlet/resources/j2ee_web_services_client_1_1.xsd
+# /javax/servlet/resources/xml.xsd=/jakarta/servlet/resources/xml.xsd
+
 # Jasper generation code constants
 (\u0020javax.servlet.jsp.JspWriter\u0020out\u0020)\u0020=(\u0020jakarta.servlet.jsp.JspWriter\u0020out\u0020)\u0020
 (javax.servlet.jsp.tagext.SimpleTag)\u0020this\u0020));=(jakarta.servlet.jsp.tagext.SimpleTag)\u0020this\u0020));
 (javax.servlet.jsp.tagext.SimpleTag)\u0020=(jakarta.servlet.jsp.tagext.SimpleTag)\u0020
 (javax.servlet.jsp.tagext.Tag)\u0020=(jakarta.servlet.jsp.tagext.Tag)\u0020
 (\u0020int\u0020discriminator,\u0020javax.servlet.jsp.JspContext\u0020jspContext,\u0020javax.servlet.jsp.tagext.JspTag\u0020_jspx_parent,\u0020int[]\u0020_jspx_push_body_count\u0020)\u0020{=(\u0020int\u0020discriminator,\u0020jakarta.servlet.jsp.JspContext\u0020jspContext,\u0020jakarta.servlet.jsp.tagext.JspTag\u0020_jspx_parent,\u0020int[]\u0020_jspx_push_body_count\u0020)\u0020{
+


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
For comparison with https://github.com/wildfly-extras/batavia/pull/90

This change merges our current settings with new ones from https://github.com/OpenLiberty/open-liberty/blob/integration/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties, with some reordering for easy comparison.

I plan to create a pull request for https://github.com/OpenLiberty/open-liberty/blob/integration/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties of these changes if we use them.