### PR TITLE
Transform missing string constants 

### DIFF
--- a/impl/ecl/src/main/resources/org/wildfly/extras/transformer/eclipse/jakarta-direct.properties
+++ b/impl/ecl/src/main/resources/org/wildfly/extras/transformer/eclipse/jakarta-direct.properties
@@ -26,6 +26,8 @@ javax.servlet.forward.servlet_path=jakarta.servlet.forward.servlet_path
 javax.servlet.http.HttpServletRequest=jakarta.servlet.http.HttpServletRequest
 javax.servlet.http.HttpServletResponse=jakarta.servlet.http.HttpServletResponse
 javax.servlet.http.HttpSession=jakarta.servlet.http.HttpSession
+javax.servlet.http.authType=jakarta.servlet.http.authType
+javax.servlet.http.registerSession=jakarta.servlet.http.registerSession
 javax.servlet.http.*=jakarta.servlet.http.*
 javax.servlet.include.context_path=jakarta.servlet.include.context_path
 javax.servlet.include.mapping=jakarta.servlet.include.mapping
@@ -41,6 +43,9 @@ javax.servlet.request.X509Certificate=jakarta.servlet.request.X509Certificate
 javax.servlet.ServletConfig=jakarta.servlet.ServletConfig
 javax.servlet.ServletContext=jakarta.servlet.ServletContext
 javax.servlet.ServletException=jakarta.servlet.ServletException
+
+# Jakarta Security
+javax.security.auth.message.MessagePolicy.isMandatory=jakarta.security.auth.message.MessagePolicy.isMandatory
 
 # Jakarta Messaging
 javax.jms.Queue=jakarta.jms.Queue


### PR DESCRIPTION
The following string constants must be transformed too:

javax.servlet.http.authType 
javax.servlet.http.registerSession 
javax.security.auth.message.MessagePolicy.isMandatory